### PR TITLE
Fix FeedMap conversion from empty map.

### DIFF
--- a/tensorflow/src/main/scala/org/platanios/tensorflow/api/core/client/Feedable.scala
+++ b/tensorflow/src/main/scala/org/platanios/tensorflow/api/core/client/Feedable.scala
@@ -89,7 +89,7 @@ object FeedMap {
 
   trait Implicits {
     implicit def feedMap[T, V](feeds: Map[T, V])(implicit ev: Feedable.Aux[T, V]): FeedMap = {
-      FeedMap(feeds.toSeq.map(f => ev.feed(f._1, f._2)).reduce(_ ++ _))
+      FeedMap(feeds.flatMap { case (k, v) => ev.feed(k, v) })
     }
   }
 


### PR DESCRIPTION
Calling `evaluate()` on an Output without a feed argument causes a
```java.lang.UnsupportedOperationException: empty.reduceLeft```

The direct fix would be to replace reduce by a fold, like this:
```scala
FeedMap(feeds.toSeq.map(f => ev.feed(f._1, f._2)).fold(Map.empty)(_ ++ _))
```
I think using just flatMap is simpler but should still be equivalent.