### PR TITLE
[WIP] Random distributions

### DIFF
--- a/tensorflow/src/main/scala/org/platanios/tensorflow/api/ops/Random.scala
+++ b/tensorflow/src/main/scala/org/platanios/tensorflow/api/ops/Random.scala
@@ -1,0 +1,144 @@
+/* Copyright 2017, Emmanouil Antonios Platanios. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.platanios.tensorflow.api.ops
+
+import org.platanios.tensorflow.api._
+import org.platanios.tensorflow.api.core.Shape
+import org.platanios.tensorflow.api.core.exception.InvalidDataTypeException
+import org.platanios.tensorflow.api.ops.Gradients.{Registry => GradientsRegistry}
+import org.platanios.tensorflow.api.tensors.Tensor
+import org.platanios.tensorflow.api.types.{FLOAT32, FLOAT64, INT32, INT64, RealNumericDataType}
+import org.platanios.tensorflow.api.utilities.RandomSeed
+
+/**
+  * Contains operations for generating random numbers.
+  *
+  * @author Sören Brunk
+  */
+trait Random {
+
+  /** Outputs random values from a normal distribution.
+    *
+    * @param shape The shape of the output tensor.
+    * @param mean The mean of the normal distribution.
+    * @param stddev The standard deviation of the normal distribution.
+    * @param dataType The type of the output.
+    * @param seed Used to create a random seed for the distribution.
+    * @param name A name for the operation (optional).
+    * @return A tensor of the specified shape filled with random normal values.
+    * @throws InvalidDataTypeException If `dataType` is neither [[FLOAT32]] nor [[FLOAT64]]
+    */
+  def randomNormal(dataType: RealNumericDataType = FLOAT32)(
+    shape: Shape,
+    mean: Tensor = Tensor.fill(dataType, Shape.scalar())(0.0),
+    stddev: Tensor = Tensor.fill(dataType, Shape.scalar())(1.0),
+    seed: Option[Int] = None,
+    name: String = "RandomNormal"
+  ): Output = {
+    if (dataType != FLOAT32 && dataType != FLOAT64) // TODO float16 once implemented
+      throw InvalidDataTypeException(s"'dataType' '$dataType', is not 'FLOAT32' or 'FLOAT64', as required.")
+    val (seed1, seed2) = RandomSeed.getSeed(seed)
+    Op.createWithNameScope(name) {
+      val builder = Op.Builder(opType = "RandomStandardNormal", name = name)
+        .addInput(shape)
+        .setAttribute("dtype", dataType)
+      seed1.foreach(builder.setAttribute("seed", _))
+      seed2.foreach(builder.setAttribute("seed2", _))
+      val randomStandardNormal = builder.build().outputs(0)
+      (randomStandardNormal * stddev) + mean
+    }
+  }
+
+  /** Outputs random values from a uniform distribution.
+    *
+    * The generated values follow a uniform distribution in the range `[minval, maxval)`.
+    * The lower bound `minval` is included in the range, while the upper bound `maxval` is excluded.
+    *
+    * For floats, the default range is `[0, 1)`.  For ints, at least `maxval` must be specified explicitly.
+    *
+    * In the integer case, the random integers are slightly biased unless `maxval - minval` is an exact power of two.
+    * The bias is small for values of `maxval - minval` significantly smaller than the range of the output (either
+    * `2**32` or `2**64`).
+    *
+    * @param shape  The shape of the output tensor.
+    * @param minval A 0-D Tensor of type `dataType`. The lower bound on the range of random values to generate.
+    *               Defaults to 0.
+    * @param maxval A 0-D Tensor of type `dataType`. The upper bound on the range of random values to generate.
+    *               Defaults to 1 if `dataType` is floating point.
+    * @param seed   Used to create a random seed for the distribution.
+    *     @see @{tf.set_random_seed}
+    *     for behavior.
+    * @param name A name for the operation (optional).
+    * @return A tensor of the specified shape filled with random uniform values.
+    * @throws IllegalArgumentException If `dataType` is integral and `maxval` is not specified or if `minval` or
+    *                                  `maxval` are non scalar.
+    * @throws InvalidDataTypeException If `dataType` isn't [[FLOAT32]], [[FLOAT64]], [[INT32]] or [[INT64]].
+    */
+  @throws[IllegalArgumentException]
+  @throws[InvalidDataTypeException]
+  def randomUniform(dataType: RealNumericDataType = FLOAT32)(
+    shape: Shape,
+    minval: Tensor = Tensor.fill(dataType, Shape.scalar())(0),
+    maxval: Option[Tensor] = None,
+    seed: Option[Int] = None,
+    name: String = "RandomUniform"): Output = {
+    if (minval.rank != 0 || minval.dataType != dataType)
+      throw new IllegalArgumentException(
+        s"'minval' (rank = ${minval.rank}, dataType = ${minval.dataType}) must be a scalar $dataType tensor.")
+    maxval.foreach { max =>
+      if (max.rank != 0 || max.dataType != dataType)
+        throw new IllegalArgumentException(
+          s"'maxval' (rank = ${max.rank}, dataType = ${max.dataType}) must be a scalar $dataType tensor.")
+    }
+    val (seed1, seed2) = RandomSeed.getSeed(seed)
+    dataType match {
+      case FLOAT32 | FLOAT64 => // TODO float16 once implemented
+        Op.createWithNameScope(name) {
+          val builder = Op.Builder(opType = "RandomUniform", name = name)
+            .addInput(shape)
+            .setAttribute("dtype", dataType)
+          seed1.foreach(builder.setAttribute("seed", _))
+          seed2.foreach(builder.setAttribute("seed2", _))
+          val rnd = builder.build().outputs(0)
+          val max = maxval.getOrElse(Tensor.fill(dataType)(1.0))
+          rnd * (max - minval)
+        }
+      case INT32 | INT64 =>
+        maxval.fold(
+          throw new IllegalArgumentException(s"Must specify maxval for integer dtype $dataType"))(
+          max => {
+            val builder = Op.Builder(opType = "RandomUniformInt", name = name)
+              .addInput(shape)
+              .addInput(minval)
+              .addInput(max)
+              .setAttribute("dtype", dataType)
+            seed1.foreach(builder.setAttribute("seed", _))
+            seed2.foreach(builder.setAttribute("seed2", _))
+            builder.build().outputs(0)
+          }
+        )
+      case _ => throw InvalidDataTypeException(
+        s"'dataType' '$dataType', is not 'FLOAT32' or 'FLOAT64' or 'INT32' or 'INT64', as required.")
+    }
+  }
+}
+
+object Random extends Random {
+  private[api] object Gradients {
+    GradientsRegistry.registerNonDifferentiable("RandomStandardNormal")
+    GradientsRegistry.registerNonDifferentiable("RandomUniform")
+  }
+}

--- a/tensorflow/src/main/scala/org/platanios/tensorflow/api/ops/package.scala
+++ b/tensorflow/src/main/scala/org/platanios/tensorflow/api/ops/package.scala
@@ -28,6 +28,7 @@ package object ops {
           with Image
           with Logging
           with Math
+          with Random
           with Text
           with variables.API {
     type Op = ops.Op

--- a/tensorflow/src/main/scala/org/platanios/tensorflow/api/utilities/RandomSeed.scala
+++ b/tensorflow/src/main/scala/org/platanios/tensorflow/api/utilities/RandomSeed.scala
@@ -1,0 +1,71 @@
+/* Copyright 2017, Emmanouil Antonios Platanios. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.platanios.tensorflow.api.utilities
+
+import org.platanios.tensorflow.api.tf.defaultGraph
+
+/**
+  * @author Sören Brunk
+  */
+object RandomSeed {
+  val defaultGraphSeed: Int = 87654321
+
+  /**
+    * Returns the local seeds an operation should use given an op-specific seed.
+    *
+    * Given operation-specific seed, opSeed, this helper function returns two
+    * seeds derived from graph-level and op-level seeds. Many random operations
+    * internally use the two seeds to allow user to change the seed globally for a
+    * graph, or for only specific operations.
+    *
+    * @param  opSeed The op-specific seed
+    *
+    * @return A tuple of two integers that should be used for the local seed of this operation.
+    */
+  def getSeed(opSeed: Option[Int]): (Option[Int], Option[Int]) = {
+
+    val graphSeed: Option[Int] = Some(defaultGraphSeed) // TODO use seed from current default graph once implemented
+
+    if (graphSeed.isEmpty && opSeed.isEmpty)(None, None)
+    else {
+      val (seed1, seed2) = (graphSeed.getOrElse(defaultGraphSeed), opSeed.getOrElse(defaultGraph.ops.length))
+      if ((seed1, seed2) == (0, 0)) (Some(seed1), Some(Int.MaxValue))
+      else (Some(seed1), Some(seed2))
+    }
+  }
+
+  /** Sets the graph-level random seed.
+    *
+    * Operations that rely on a random seed actually derive it from two seeds:
+    * the graph-level and operation-level seeds. This sets the graph-level seed.
+    *
+    * Its interactions with operation-level seeds is as follows:
+    *
+    *   1. If neither the graph-level nor the operation seed is set:
+    *     A random seed is used for this op.
+    *   2. If the graph-level seed is set, but the operation seed is not:
+    *     The system deterministically picks an operation seed in conjunction
+    *     with the graph-level seed so that it gets a unique random sequence.
+    *   3. If the graph-level seed is not set, but the operation seed is set:
+    *     A default graph-level seed and the specified operation seed are used to
+    *     determine the random sequence.
+    *   4. If both the graph-level and the operation seed are set:
+    *     Both seeds are used in conjunction to determine the random sequence.
+    *
+    * @param seed The new graph-level random seed.
+    */
+  def setRandomSeed(seed: Int): Unit = ???
+}

--- a/tensorflow/src/test/scala/org/platanios/tensorflow/api/ops/RandomSpec.scala
+++ b/tensorflow/src/test/scala/org/platanios/tensorflow/api/ops/RandomSpec.scala
@@ -1,0 +1,58 @@
+/* Copyright 2017, Emmanouil Antonios Platanios. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.platanios.tensorflow.api.ops
+
+import org.platanios.tensorflow.api._
+import org.platanios.tensorflow.api.tensors.RealNumericTensor
+import org.scalactic.{Equality, Equivalence, TolerantNumerics, TypeCheckedTripleEquals}
+import org.scalatest._
+
+/**
+  * @author Sören Brunk
+  */
+class RandomSpec extends FlatSpec with Matchers with TypeCheckedTripleEquals{
+
+  val epsilon = 1e-4f
+  val randomSeed = 42
+
+  implicit val tolerantNumericTensorEq = new Equivalence[RealNumericTensor] {
+    override def areEquivalent(a: RealNumericTensor, b: RealNumericTensor): Boolean = {
+      a.shape == b.shape &&
+      a.dataType == b.dataType &&
+      //a.entriesIterator.map{case v: Float => v}.zip(b.entriesIterator.map{case v: Float => v}).forall(p => p._1 === p._2) &&
+      a == b +- epsilon // TODO cleaner tolerant equals
+  }}
+
+  "The random normal distribution op" must "produce correct and predictable FLOAT32 values" in {
+    val session = tf.Session
+    val rnd = tf.randomNormal()(tf.Shape(2,2), seed = Some(randomSeed))
+    val result = rnd.evaluate()
+    val expectedResult = tf.Tensor(tf.FLOAT32,
+      tf.Tensor(-0.28077507, -0.1377521),
+      tf.Tensor(-0.67632961, 0.02458041))
+    assert(result.asRealNumeric === expectedResult.asRealNumeric)
+  }
+
+  "The random uniform distribution op" must "produce correct and predictable FLOAT32 values" in {
+    val session = tf.Session
+    val rnd = tf.randomUniform()(tf.Shape(2,2), seed = Some(randomSeed))
+    val result = rnd.evaluate()
+    val expectedResult = tf.Tensor(tf.FLOAT32,
+      tf.Tensor(0.95227146, 0.67740774),
+      tf.Tensor(0.79531825, 0.75578177))
+    assert(result.asRealNumeric === expectedResult.asRealNumeric)
+  }
+}


### PR DESCRIPTION
To get to know the codebase better, I've added ops for creating random uniform/normal distribution tensors.

Open questions:
* The Python API has a graph-level [random seed attribute](https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/framework/ops.py#L2131). Should we do the same and add it to `Graph`?
* Better type safety for parameters (Might make sense to revisit when the data types API is final).
  * I wonder if it's possible to restrict the parameter values dataType to e.g. float16/32/64 at compile time somehow.
  * For now the functions take just untyped Tensors even for scalar parameters like mean. I tried overloading with float/double instead but that doesn't work in combination with default parameters.

I know you're still traveling so no hurries. Perhaps you could have a look when you're back.