### PR TITLE
Make the tensor representation of scalar shapes consistent with upstream

### DIFF
--- a/api/src/main/scala/org/platanios/tensorflow/api/core/Shape.scala
+++ b/api/src/main/scala/org/platanios/tensorflow/api/core/Shape.scala
@@ -307,7 +307,9 @@ final class Shape private (private val array: Array[Int]) extends OutputConverti
     * @return One-dimensional tensor representing this shape.
     */
   def toTensor(dataType: DataType = INT32): Tensor = {
-    if (rank == 1)
+    if (rank == 0)
+      Tensor(dataType)
+    else if (rank == 1)
       Tensor(dataType, array(0))
     else
       Tensor.fromSeq(dataType, asArray: _*)
@@ -317,7 +319,7 @@ final class Shape private (private val array: Array[Int]) extends OutputConverti
     *
     * @return One-dimensional op output tensor representing this shape.
     */
-  def toOutput: Output = toOutput(dataType = INT32, name = "Shape")
+  def toOutput: Output = toOutput(dataType = INT32)
 
   /** Converts this shape to a one-dimensional "symbolic" tensor (i.e., a constant-valued op output).
     *


### PR DESCRIPTION
Trying the random distribution ops with default arguments gave me the following error:

```
scala> tf.randomNormal()
java.lang.IllegalArgumentException: Shape must be rank 1 but is rank 0 for 'RandomNormal_4/RandomNormal' (op: 'RandomStandardNormal') with input shapes: [].
  at org.platanios.tensorflow.jni.Op$.finish(Native Method)
  at org.platanios.tensorflow.api.ops.Op$Builder.$anonfun$build$1(Op.scala:1024)
  at org.platanios.tensorflow.api.package$.using(package.scala:58)
  at org.platanios.tensorflow.api.ops.Op$Builder.build(Op.scala:1001)
  at org.platanios.tensorflow.api.ops.Random.$anonfun$randomNormal$1(Random.scala:109)
  at scala.util.DynamicVariable.withValue(DynamicVariable.scala:58)
  at org.platanios.tensorflow.api.ops.Op$.createWithNameScope(Op.scala:709)
  at org.platanios.tensorflow.api.ops.Random.randomNormal(Random.scala:101)
  at org.platanios.tensorflow.api.ops.Random.randomNormal$(Random.scala:96)
  at org.platanios.tensorflow.api.package$API$.randomNormal(package.scala:80)
  ... 39 elided
```

This also happens with other ops like `tf.fill`.

Apparently, in the Python API the tensor representation of a scalar shape is a zero length 1-D tensor:
```python
>>> import tensorflow as tf   
>>> tf.convert_to_tensor(tf.TensorShape(()))
<tf.Tensor 'shape_as_tensor_8:0' shape=(0,) dtype=int32>
```
This is also expected by the native API so I think it makes sense to do the same if it doesn't cause other issues.
