### PR TITLE
Implement nicely formatted numpy style tensor summarize

### DIFF
--- a/api/src/main/scala/org/platanios/tensorflow/api/tensors/TensorLike.scala
+++ b/api/src/main/scala/org/platanios/tensorflow/api/tensors/TensorLike.scala
@@ -31,5 +31,5 @@ trait TensorLike extends TensorConvertible {
   def rank: Int = shape.rank
   def numElements: Int = shape.numElements
 
-  def summarize(maxEntries: Int = numElements): String
+  def summarize(maxEntries: Int = 6): String
 }


### PR DESCRIPTION
Formatting of floats and strings could still be polished but I think it's already quite helpful as is.

```scala
import org.platanios.tensorflow.api._

scala> val v = tf.Tensor(1.0, 2.34, 0.5)
v: org.platanios.tensorflow.api.tensors.Tensor = FLOAT64[3]

scala> println(v.summarize())
FLOAT64[3]
[1.0, 2.34, 0.5]

scala> val t = tf.Tensor.fill(tf.INT32, tf.shape(3,3))(42)
t: org.platanios.tensorflow.api.tensors.Tensor = INT32[3, 3]
scala> println(t.summarize())
INT32[3, 3]
[[42, 42, 42],
 [42, 42, 42],
 [42, 42, 42]]

scala> val t2 = tf.Tensor.fill(tf.INT32, tf.shape(7,7,7))(42)
t2: org.platanios.tensorflow.api.tensors.Tensor = INT32[7, 7, 7]

scala> println(t2.summarize())
INT32[7, 7, 7]
[[[42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  ...,
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42]],

 [[42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  ...,
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42]],

 [[42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  ...,
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42]],

 ...,

 [[42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  ...,
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42]],

 [[42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  ...,
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42]],

 [[42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  ...,
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42],
  [42, 42, 42, ..., 42, 42, 42]]]

```

