### PR TITLE
Make hardcoded paths in examples relative to the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project Specific
 temp/
+datasets/
 
 # Scala Specific
 *.class

--- a/examples/src/main/scala/org/platanios/tensorflow/examples/CIFAR.scala
+++ b/examples/src/main/scala/org/platanios/tensorflow/examples/CIFAR.scala
@@ -31,7 +31,7 @@ object CIFAR {
   private[this] val logger = Logger(LoggerFactory.getLogger("Examples / CIFAR"))
 
   def main(args: Array[String]): Unit = {
-    val dataSet = CIFARLoader.load(Paths.get("/Users/Anthony/Downloads/CIFAR"), CIFARLoader.CIFAR_10)
+    val dataSet = CIFARLoader.load(Paths.get("datasets/CIFAR"), CIFARLoader.CIFAR_10)
     val trainImages = tf.data.TensorSlicesDataset(dataSet.trainImages)
     val trainLabels = tf.data.TensorSlicesDataset(dataSet.trainLabels)
     val trainData =
@@ -62,7 +62,7 @@ object CIFAR {
     val model = tf.learn.Model(input, layer, trainInput, trainingInputLayer, loss, optimizer)
 
     logger.info("Training the linear regression model.")
-    val summariesDir = Paths.get("/Users/Anthony/Downloads/temp")
+    val summariesDir = Paths.get("temp/cnn-cifar")
     val estimator = tf.learn.InMemoryEstimator(
       model,
       tf.learn.Configuration(Some(summariesDir)),

--- a/examples/src/main/scala/org/platanios/tensorflow/examples/MNIST.scala
+++ b/examples/src/main/scala/org/platanios/tensorflow/examples/MNIST.scala
@@ -37,7 +37,7 @@ object MNIST {
   //  }
 
   def main(args: Array[String]): Unit = {
-    val dataSet = MNISTLoader.load(Paths.get("/Users/Anthony/Downloads/MNIST"))
+    val dataSet = MNISTLoader.load(Paths.get("datasets/MNIST"))
     val trainImages = tf.data.TensorSlicesDataset(dataSet.trainImages)
     val trainLabels = tf.data.TensorSlicesDataset(dataSet.trainLabels)
     val trainData =
@@ -65,7 +65,7 @@ object MNIST {
     val model = tf.learn.Model(input, layer, trainInput, trainingInputLayer, loss, optimizer)
 
     logger.info("Training the linear regression model.")
-    val summariesDir = Paths.get("/Users/Anthony/Downloads/temp/mlp-1024-256-64")
+    val summariesDir = Paths.get("temp/mnist-mlp")
     val estimator = tf.learn.InMemoryEstimator(
       model,
       tf.learn.Configuration(Some(summariesDir)),

--- a/examples/src/main/scala/org/platanios/tensorflow/examples/RNNTutorialUsingPTB.scala
+++ b/examples/src/main/scala/org/platanios/tensorflow/examples/RNNTutorialUsingPTB.scala
@@ -77,13 +77,13 @@ object RNNTutorialUsingPTB {
   }
 
   def main(args: Array[String]): Unit = {
-    val dataset = PTBLoader.load(Paths.get("/Users/Anthony/Downloads/temp/PTB"))
+    val dataset = PTBLoader.load(Paths.get("datasets/PTB"))
     val trainDataset =
       PTBLoader.tokensToBatchedTFDataset(dataset.train, batchSize, numSteps, "TrainDataset")
           .repeat()
           .prefetch(prefetchSize)
 
-    val summariesDir = Paths.get("/Users/Anthony/Downloads/temp/rnn-ptb")
+    val summariesDir = Paths.get("temp/rnn-ptb")
     val estimator = tf.learn.InMemoryEstimator(
       model,
       tf.learn.Configuration(Some(summariesDir)),

--- a/examples/src/main/scala/org/platanios/tensorflow/examples/STL10.scala
+++ b/examples/src/main/scala/org/platanios/tensorflow/examples/STL10.scala
@@ -31,7 +31,7 @@ object STL10 {
   private[this] val logger = Logger(LoggerFactory.getLogger("Examples / STL10"))
 
   def main(args: Array[String]): Unit = {
-    val dataSet = STL10Loader.load(Paths.get("~/data/STL10"), loadUnlabeled = false)
+    val dataSet = STL10Loader.load(Paths.get("datasets/STL10"), loadUnlabeled = false)
     val trainImages = tf.data.TensorSlicesDataset(dataSet.trainImages)
     val trainLabels = tf.data.TensorSlicesDataset(dataSet.trainLabels)
     val trainData =
@@ -62,7 +62,7 @@ object STL10 {
     val model = tf.learn.Model(input, layer, trainInput, trainingInputLayer, loss, optimizer)
 
     logger.info("Training the linear regression model.")
-    val summariesDir = Paths.get("~/temp/mlp-1024-256-64")
+    val summariesDir = Paths.get("temp/cnn-stl10")
     val estimator = tf.learn.InMemoryEstimator(
       model,
       tf.learn.Configuration(Some(summariesDir)),


### PR DESCRIPTION
Right now, running the examples without changes only works on @eaplatanios machine ;-)

Since the examples are usually run from the source tree via SBT/IDE, the dataset download paths and working dirs are just relative to the the project directory.