### PR TITLE
Make matrixBandPart work with other integer types than INT64

### DIFF
--- a/api/src/main/scala/org/platanios/tensorflow/api/ops/Math.scala
+++ b/api/src/main/scala/org/platanios/tensorflow/api/ops/Math.scala
@@ -1796,10 +1796,15 @@ private[api] trait Math {
     */
   def matrixBandPart(
       input: Output, numSubDiagonals: Output, numSuperDiagonals: Output, name: String = "MatrixBandPart"): Output = {
+    if(!numSubDiagonals.dataType.isInteger)
+      throw new IllegalArgumentException("MatrixBandPart: numSubDiagonals needs to be an integer")
+    if(!numSuperDiagonals.dataType.isInteger)
+      throw new IllegalArgumentException("MatrixBandPart: numSuperDiagonals needs to be an integer")
+
     Op.Builder(opType = "MatrixBandPart", name = name)
         .addInput(input)
-        .addInput(numSubDiagonals)
-        .addInput(numSuperDiagonals)
+        .addInput(cast(numSubDiagonals, INT64))
+        .addInput(cast(numSuperDiagonals, INT64))
         .build().outputs(0)
   }
 


### PR DESCRIPTION
I would expect the following code to work:

```
import org.platanios.tensorflow.api._

object MatrixBandPart {
  def main(args: Array[String]): Unit = {
    tf.matrixBandPart(Seq(Seq(0)), 0, 0)
  }
}
```

However it does not, because `matrixBandPart` expects `INT64` arguments.
The changes make this work, and introduces checks to not cast e.g. `float`.