### PR TITLE
Remove overly restrictive assertion in addNOutputIndexedSlices

### DIFF
--- a/api/src/main/scala/org/platanios/tensorflow/api/ops/Gradients.scala
+++ b/api/src/main/scala/org/platanios/tensorflow/api/ops/Gradients.scala
@@ -480,10 +480,6 @@ private[ops] object Gradients {
            } else if (gradients.length == 1) {
              gradients.head
            } else {
-             assert(
-               gradients.forall(_.denseShape == gradients.head.denseShape),
-               "The indexed slices being aggregated must all have the same dense shape, but they did not. " +
-                   "There must be a bug somewhere in the gradients code.")
              OutputIndexedSlices(
                Basic.concatenate(gradients.map(_.indices)),
                Basic.concatenate(gradients.map(_.values)),


### PR DESCRIPTION
The assertion in `addNOutputIndexedSlices` is overly restrictive, because the `denseShape` might be always equal during execution despite the associated `Output` being different.
This breaks the following code:
```
import org.platanios.tensorflow.api._
import org.platanios.tensorflow.api.ops.variables.ZerosInitializer

object GradientAggregation {
  def main(args: Array[String]): Unit = {
    val a = tf.variable("a", FLOAT32, Shape(1), ZerosInitializer)
    val concatenated = tf.concatenate(Seq(a, a))
    val gathered = tf.gather(concatenated, Tensor(1))
    val loss = gathered.sum()
    tf.Gradients.gradients(Seq(loss), Seq(a))
  }
}
```

I hesitated to add a `tf.assert` to dynamically check the shape, but I don't think you would always want that because of the possible slowdown.
