### PR TITLE
Fix bug in sliceGradient

### DIFF
--- a/api/src/main/scala/org/platanios/tensorflow/api/ops/Basic.scala
+++ b/api/src/main/scala/org/platanios/tensorflow/api/ops/Basic.scala
@@ -2339,7 +2339,7 @@ object Basic extends Basic {
       val inputVector = op.inputs(0)
       val beginVector = op.inputs(1)
       val inputRank = rank(inputVector)
-      val padShape = stack(Seq(inputRank, constant(Tensor(inputRank.dataType, 1))))
+      val padShape = concatenate(Seq(expandDims(inputRank, 0), constant(Tensor(inputRank.dataType, 1))))
       val beforePad = reshape(beginVector, padShape)
       val afterPad = reshape(shape(inputVector) - shape(op.outputs(0)) - beginVector, padShape)
       val paddings = concatenate(Seq(beforePad, afterPad), axis = 1)


### PR DESCRIPTION
The problem was that `inputRank` has shape `[]`, while `constant(Tensor(inputRank.dataType, 1))` has shape `[1]`.
Thanks!