### PR TITLE
Launch tensorboard binary directly making it work with python3 as well

### DIFF
--- a/api/src/main/scala/org/platanios/tensorflow/api/config/TensorBoardConfig.scala
+++ b/api/src/main/scala/org/platanios/tensorflow/api/config/TensorBoardConfig.scala
@@ -34,7 +34,7 @@ case class TensorBoardConfig(
     port: Int = 6006,
     reloadInterval: Int = 5) {
   private[api] val processBuilder = new ProcessBuilder(
-    "python", "-m", "tensorboard.main",
+    "tensorboard",
     "--logdir", logDir.toAbsolutePath.toString,
     "--host", host,
     "--port", port.toString,


### PR DESCRIPTION
Also print warnings if tensorboard couldn't be found. This could also help with #58 

Note that this still doesn't catch the possibility of TensorBoard starting but returning immediately with an error. Checking the exitcode is a bit more involved because it requires correct timing and dealing with threads.

It does cover the most common error case of having tensorboard not on the path though.

I've tested this with running sbt in a virtualenv with Python 2 and 3, respectively.

