### PR TITLE
Add ops for jpeg decoding/encoding

### DIFF
--- a/api/src/main/scala/org/platanios/tensorflow/api/ops/Image.scala
+++ b/api/src/main/scala/org/platanios/tensorflow/api/ops/Image.scala
@@ -47,41 +47,72 @@ private[ops] trait Image {
         .build().outputs(0)
   }
 
+  /** Dct method used for JPEG decoding. **/
+  sealed trait DctMethod
+
+  object DctMethod {
+    case object IntegerFast extends DctMethod
+    case object IntegerAccurate extends DctMethod
+    case object SystemDefault extends DctMethod
+  }
+
   /** $OpDocImageDecodeJpeg
     *
     * @group ImageOps
-    * @param contents              0-D [[Output]] of type [[org.platanios.tensorflow.api.types.STRING]].
-    *                              The JPEG-encoded image.
-    * @param channels              Number of color channels for the decoded image. Defaults to 0.
-    * @param ratio                 Downscaling ratio. Defaults to 1.
-    * @param fancy_upscaling       If true use a slower but nicer upscaling of the chroma planes (yuv420/422 only).
-    *                              Defaults to true.
-    * @param try_recover_truncated If true try to recover an image from truncated input. Defaults to false.
-    * @param acceptable_fraction   The minimum required fraction of lines before a truncated input is accepted.
-    *                              Defaults to 1.
-    * @param dct_method            String specifying a hint about the algorithm used for decompression.
-    *                              Defaults to "" which maps to a system-specific default.
-    *                              Currently valid values are ["INTEGER_FAST", "INTEGER_ACCURATE"].
-    *                              The hint may be ignored (e.g., the internal jpeg library changes to a version that
-    *                              does not have that specific option.)
-    * @param name                  Name for the created op.
+    * @param contents            0-D [[Output]] of type [[org.platanios.tensorflow.api.types.STRING]].
+    *                            The JPEG-encoded image.
+    * @param channels            Number of color channels for the decoded image. Defaults to 0.
+    * @param ratio               Downscaling ratio. Defaults to 1.
+    * @param fancyUpscaling      If true use a slower but nicer upscaling of the chroma planes (yuv420/422 only).
+    *                            Defaults to true.
+    * @param tryRecoverTruncated If true try to recover an image from truncated input. Defaults to false.
+    * @param acceptableFraction  The minimum required fraction of lines before a truncated input is accepted.
+    *                            Defaults to 1.
+    * @param dctMethod           Specifies a hint about the algorithm used for decompression.
+    *                            Defaults to [[DctMethod.SystemDefault]] which maps to a system-specific default.
+    *                            The hint may be ignored (e.g., the internal jpeg library changes to a version that
+    *                            does not have that specific option.)
+    * @param name                Name for the created op.
 
     * @return 3-D [[Output]] of type [[org.platanios.tensorflow.api.types.UINT8]]
     *         with shape `[height, width, channels]`.
     */
   def decodeJpeg(
-      contents: Output, channels: Int = 0, ratio: Int = 1, fancy_upscaling: Boolean = true,
-      try_recover_truncated: Boolean = false, acceptable_fraction: Float = 1, dct_method: String = "",
+      contents: Output, channels: Int = 0, ratio: Int = 1, fancyUpscaling: Boolean = true,
+      tryRecoverTruncated: Boolean = false, acceptableFraction: Float = 1,
+      dctMethod: DctMethod = DctMethod.SystemDefault,
       name: String = "DecodeJpeg"): Output = {
+    val dctMethodString = dctMethod match {
+      case DctMethod.IntegerFast => "INTEGER_FAST"
+      case DctMethod.IntegerAccurate => "INTEGER_ACCURATE"
+      case DctMethod.SystemDefault => ""
+    }
     Op.Builder(opType = "DecodeJpeg", name = name)
       .addInput(contents)
       .setAttribute("channels", channels)
       .setAttribute("ratio", ratio)
-      .setAttribute("fancy_upscaling", fancy_upscaling)
-      .setAttribute("try_recover_truncated", try_recover_truncated)
-      .setAttribute("acceptable_fraction", acceptable_fraction)
-      .setAttribute("dct_method", dct_method)
+      .setAttribute("fancy_upscaling", fancyUpscaling)
+      .setAttribute("try_recover_truncated", tryRecoverTruncated)
+      .setAttribute("acceptable_fraction", acceptableFraction)
+      .setAttribute("dct_method", dctMethodString)
       .build().outputs(0)
+  }
+
+  /** Format of the image tensor. **/
+  sealed trait ImageFormat
+
+  object ImageFormat {
+    case object Grayscale extends ImageFormat
+    case object RGB extends ImageFormat
+    case object Default extends ImageFormat
+  }
+
+  /** Per pixel density unit. */
+  sealed trait DensityUnit
+
+  object DensityUnit {
+    case object Inch extends DensityUnit
+    case object Centimeter extends DensityUnit
   }
 
   /** $OpDocImageEncodeJpeg
@@ -89,14 +120,16 @@ private[ops] trait Image {
     * @group ImageOps
     * @param image              3-D [[Output]] of type [[org.platanios.tensorflow.api.types.UINT8]]
     *                           with shape `[height, width, channels]`.
-    * @param format             Per pixel image format. One of `"", "grayscale", "rgb"`. Defaults to `""`.
+    * @param format             Per pixel image format. One of [[ImageFormat.Default]], [[ImageFormat.Grayscale]],
+    *                           [[ImageFormat.RGB]].
     * @param quality            Quality of the compression from 0 to 100 (higher is better and slower).
     *                           Defaults to `95`.
-    * @param progressive        If True, create a JPEG that loads progressively (coarse to fine). Defaults to `False`.
-    * @param optimizeSize       If True, spend CPU/RAM to reduce size with no quality change. Defaults to `false`.
+    * @param progressive        If true, create a JPEG that loads progressively (coarse to fine). Defaults to `false`.
+    * @param optimizeSize       If true, spend CPU/RAM to reduce size with no quality change. Defaults to `false`.
     * @param chromaDownsampling See [[http://en.wikipedia.org/wiki/Chroma_subsampling]]. Defaults to `true`.
-    * @param densityUnit        Unit used to specify `x_density` and `y_density`:
-    *                           pixels per inch (`"in"`) or centimeter (`"cm"`). Defaults to `"in"`.
+    * @param densityUnit        Unit used to specify `xDensity` and `yDensity`:
+    *                           Pixels per inch [[DensityUnit.Inch]] or centimeter [[DensityUnit.Centimeter]].
+    *                           Defaults to [[DensityUnit.Inch]].
     * @param xDensity           Horizontal pixels per density unit. Defaults to `300`.
     * @param yDensity           Vertical pixels per density unit. Defaults to `300`.
     * @param xmpMetadata        If not empty, embed this XMP metadata in the image header. Defaults to `""`.
@@ -105,18 +138,27 @@ private[ops] trait Image {
     * @return 0-D [[Output]] of type [[org.platanios.tensorflow.api.types.STRING]] containing the JPEG-encoded image.
     */
   def encodeJpeg(
-      image: Output, format: String = "", quality: Int = 95, progressive: Boolean = false,
-      optimizeSize: Boolean = false, chromaDownsampling: Boolean = true, densityUnit: String = "in",
+      image: Output, format: ImageFormat = ImageFormat.Default, quality: Int = 95, progressive: Boolean = false,
+      optimizeSize: Boolean = false, chromaDownsampling: Boolean = true, densityUnit: DensityUnit = DensityUnit.Inch,
       xDensity: Int = 300, yDensity: Int = 300, xmpMetadata: String = "",
       name: String = "EncodeJpeg"): Output = {
+    val formatAttribute = format match {
+      case ImageFormat.Grayscale => "grayscale"
+      case ImageFormat.RGB => "rgb"
+      case ImageFormat.Default => ""
+    }
+    val densityUnitAttribute = densityUnit match {
+      case DensityUnit.Inch => "in"
+      case DensityUnit.Centimeter => "cm"
+    }
     Op.Builder(opType = "EncodeJpeg", name = name)
       .addInput(image)
-      .setAttribute("format", format)
+      .setAttribute("format", formatAttribute)
       .setAttribute("quality", quality)
       .setAttribute("progressive", progressive)
       .setAttribute("optimize_size", optimizeSize)
       .setAttribute("chroma_downsampling", chromaDownsampling)
-      .setAttribute("density_unit", densityUnit)
+      .setAttribute("density_unit", densityUnitAttribute)
       .setAttribute("x_density", xDensity)
       .setAttribute("y_density", yDensity)
       .setAttribute("xmp_metadata", xmpMetadata)
@@ -127,10 +169,11 @@ private[ops] trait Image {
 private[ops] object Image extends Image {
   /** @define OpDocImageExtractImagePatches
     *   The `extractImagePatches` op extracts `patches` from `images` and puts them in the `depth` output dimension.
-    * @define OpDocDecodeJpeg
-    *   Decodes a JPEG-encoded image to a [[org.platanios.tensorflow.api.types.UINT8]] tensor.
     *
-    *   The attr `channels` indicates the desired number of color channels for the decoded image.
+    * @define OpDocImageDecodeJpeg
+    *   The `decodeJpeg` op decodes a JPEG-encoded image to a [[org.platanios.tensorflow.api.types.UINT8]] tensor.
+    *
+    *   The attribute `channels` indicates the desired number of color channels for the decoded image.
     *
     *   Accepted values are:
     *     0: Use the number of channels in the JPEG-encoded image.
@@ -139,20 +182,21 @@ private[ops] object Image extends Image {
     *
     *   If needed, the JPEG-encoded image is transformed to match the requested number of color channels.
     *
-    *   The attr `ratio` allows downscaling the image by an integer factor during decoding.
+    *   The attribute `ratio` allows downscaling the image by an integer factor during decoding.
     *   Allowed values are: 1, 2, 4, and 8.  This is much faster than downscaling the image later.
-    * @define OpDocEncodeJpeg
-    *   JPEG-encode an image.
+    *
+    * @define OpDocImageEncodeJpeg
+    *   The `encodeJpeg` op encodes an image tensor as JPEG.
     *
     *   `image` is a 3-D uint8 Tensor of shape `[height, width, channels]`.
     *
-    *   The attr `format` can be used to override the color format of the encoded output.  Values can be:
-    *     `''`: Use a default format based on the number of channels in the image.
-    *     `grayscale`: Output a grayscale JPEG image.  The `channels` dimension of `image` must be 1.
-    *     `rgb`: Output an RGB JPEG image. The `channels` dimension of `image` must be 3.
+    *   The attribute `format` can be used to override the color format of the encoded output.  Values can be:
+    *     [[ImageFormat.Default]]: Use a default format based on the number of channels in the image.
+    *     [[ImageFormat.Grayscale]]: Output a grayscale JPEG image.  The `channels` dimension of `image` must be 1.
+    *     [[ImageFormat.RGB]]: Output an RGB JPEG image. The `channels` dimension of `image` must be 3.
     *
-    *   If `format` is not specified or is the empty string, a default format is picked
-    *   in function of the number of channels in `image`:
+    *   If `format` is set to [[ImageFormat.Default]], a default format is picked in function of the number of channels
+    *   in `image`:
     *     1: Output a grayscale image.
     *     3: Output an RGB image.
     */

--- a/api/src/main/scala/org/platanios/tensorflow/api/ops/Image.scala
+++ b/api/src/main/scala/org/platanios/tensorflow/api/ops/Image.scala
@@ -18,6 +18,7 @@ package org.platanios.tensorflow.api.ops
 /** Contains functions for constructing ops related to processing image data.
   *
   * @author Emmanouil Antonios Platanios
+  * @author Sören Brunk
   */
 private[ops] trait Image {
   /** $OpDocImageExtractImagePatches
@@ -45,11 +46,115 @@ private[ops] trait Image {
         .setAttribute("rates", rates.map(_.toLong).toArray)
         .build().outputs(0)
   }
+
+  /** $OpDocImageDecodeJpeg
+    *
+    * @group ImageOps
+    * @param contents              0-D [[Output]] of type [[org.platanios.tensorflow.api.types.STRING]].
+    *                              The JPEG-encoded image.
+    * @param channels              Number of color channels for the decoded image. Defaults to 0.
+    * @param ratio                 Downscaling ratio. Defaults to 1.
+    * @param fancy_upscaling       If true use a slower but nicer upscaling of the chroma planes (yuv420/422 only).
+    *                              Defaults to true.
+    * @param try_recover_truncated If true try to recover an image from truncated input. Defaults to false.
+    * @param acceptable_fraction   The minimum required fraction of lines before a truncated input is accepted.
+    *                              Defaults to 1.
+    * @param dct_method            String specifying a hint about the algorithm used for decompression.
+    *                              Defaults to "" which maps to a system-specific default.
+    *                              Currently valid values are ["INTEGER_FAST", "INTEGER_ACCURATE"].
+    *                              The hint may be ignored (e.g., the internal jpeg library changes to a version that
+    *                              does not have that specific option.)
+    * @param name                  Name for the created op.
+
+    * @return 3-D [[Output]] of type [[org.platanios.tensorflow.api.types.UINT8]]
+    *         with shape `[height, width, channels]`.
+    */
+  def decodeJpeg(
+      contents: Output, channels: Int = 0, ratio: Int = 1, fancy_upscaling: Boolean = true,
+      try_recover_truncated: Boolean = false, acceptable_fraction: Float = 1, dct_method: String = "",
+      name: String = "DecodeJpeg"): Output = {
+    Op.Builder(opType = "DecodeJpeg", name = name)
+      .addInput(contents)
+      .setAttribute("channels", channels)
+      .setAttribute("ratio", ratio)
+      .setAttribute("fancy_upscaling", fancy_upscaling)
+      .setAttribute("try_recover_truncated", try_recover_truncated)
+      .setAttribute("acceptable_fraction", acceptable_fraction)
+      .setAttribute("dct_method", dct_method)
+      .build().outputs(0)
+  }
+
+  /** $OpDocImageEncodeJpeg
+    *
+    * @group ImageOps
+    * @param image              3-D [[Output]] of type [[org.platanios.tensorflow.api.types.UINT8]]
+    *                           with shape `[height, width, channels]`.
+    * @param format             Per pixel image format. One of `"", "grayscale", "rgb"`. Defaults to `""`.
+    * @param quality            Quality of the compression from 0 to 100 (higher is better and slower).
+    *                           Defaults to `95`.
+    * @param progressive        If True, create a JPEG that loads progressively (coarse to fine). Defaults to `False`.
+    * @param optimizeSize       If True, spend CPU/RAM to reduce size with no quality change. Defaults to `false`.
+    * @param chromaDownsampling See [[http://en.wikipedia.org/wiki/Chroma_subsampling]]. Defaults to `true`.
+    * @param densityUnit        Unit used to specify `x_density` and `y_density`:
+    *                           pixels per inch (`"in"`) or centimeter (`"cm"`). Defaults to `"in"`.
+    * @param xDensity           Horizontal pixels per density unit. Defaults to `300`.
+    * @param yDensity           Vertical pixels per density unit. Defaults to `300`.
+    * @param xmpMetadata        If not empty, embed this XMP metadata in the image header. Defaults to `""`.
+    * @param name               Name for the created op.
+
+    * @return 0-D [[Output]] of type [[org.platanios.tensorflow.api.types.STRING]] containing the JPEG-encoded image.
+    */
+  def encodeJpeg(
+      image: Output, format: String = "", quality: Int = 95, progressive: Boolean = false,
+      optimizeSize: Boolean = false, chromaDownsampling: Boolean = true, densityUnit: String = "in",
+      xDensity: Int = 300, yDensity: Int = 300, xmpMetadata: String = "",
+      name: String = "EncodeJpeg"): Output = {
+    Op.Builder(opType = "EncodeJpeg", name = name)
+      .addInput(image)
+      .setAttribute("format", format)
+      .setAttribute("quality", quality)
+      .setAttribute("progressive", progressive)
+      .setAttribute("optimize_size", optimizeSize)
+      .setAttribute("chroma_downsampling", chromaDownsampling)
+      .setAttribute("density_unit", densityUnit)
+      .setAttribute("x_density", xDensity)
+      .setAttribute("y_density", yDensity)
+      .setAttribute("xmp_metadata", xmpMetadata)
+      .build().outputs(0)
+  }
 }
 
 private[ops] object Image extends Image {
   /** @define OpDocImageExtractImagePatches
     *   The `extractImagePatches` op extracts `patches` from `images` and puts them in the `depth` output dimension.
+    * @define OpDocDecodeJpeg
+    *   Decodes a JPEG-encoded image to a [[org.platanios.tensorflow.api.types.UINT8]] tensor.
+    *
+    *   The attr `channels` indicates the desired number of color channels for the decoded image.
+    *
+    *   Accepted values are:
+    *     0: Use the number of channels in the JPEG-encoded image.
+    *     1: output a grayscale image.
+    *     3: output an RGB image.
+    *
+    *   If needed, the JPEG-encoded image is transformed to match the requested number of color channels.
+    *
+    *   The attr `ratio` allows downscaling the image by an integer factor during decoding.
+    *   Allowed values are: 1, 2, 4, and 8.  This is much faster than downscaling the image later.
+    * @define OpDocEncodeJpeg
+    *   JPEG-encode an image.
+    *
+    *   `image` is a 3-D uint8 Tensor of shape `[height, width, channels]`.
+    *
+    *   The attr `format` can be used to override the color format of the encoded output.  Values can be:
+    *     `''`: Use a default format based on the number of channels in the image.
+    *     `grayscale`: Output a grayscale JPEG image.  The `channels` dimension of `image` must be 1.
+    *     `rgb`: Output an RGB JPEG image. The `channels` dimension of `image` must be 3.
+    *
+    *   If `format` is not specified or is the empty string, a default format is picked
+    *   in function of the number of channels in `image`:
+    *     1: Output a grayscale image.
+    *     3: Output an RGB image.
     */
   private[ops] trait Documentation
 }


### PR DESCRIPTION
Fixes #32.

Starting with JPEG because that's what I needed first. I hope to be able to add the PNG codec ops as well soon.

@eaplatanios while trying this out, I realized that the [Files](
https://github.com/eaplatanios/tensorflow_scala/blob/master/api/src/main/scala/org/platanios/tensorflow/api/ops/io/Files.scala) ops readFile/writeFile are private. Is this on purpose? If not, I can create PR adding it to the API, i've done it locally already in order to read some images.
