### PR TITLE
Tensor::entriesIterator memleak fix, Disposer concurrency, JDK 10 compat.

### DIFF
--- a/api/src/main/scala/org/platanios/tensorflow/api/core/client/SessionConfig.scala
+++ b/api/src/main/scala/org/platanios/tensorflow/api/core/client/SessionConfig.scala
@@ -190,7 +190,7 @@ case class SessionConfig(
 ) extends ProtoSerializable {
   val configProto: ConfigProto = {
     val configProto = ConfigProto.newBuilder()
-    deviceCount.foreach(d => configProto.putAllDeviceCount(d.mapValues(c => new Integer(c)).asJava))
+    deviceCount.foreach(d => configProto.putAllDeviceCount(d.mapValues(Integer.valueOf).asJava))
     intraOpParallelismThreads.foreach(configProto.setIntraOpParallelismThreads)
     interOpParallelismThreads.foreach(configProto.setInterOpParallelismThreads)
     usePerSessionThreads.foreach(configProto.setUsePerSessionThreads)


### PR DESCRIPTION
[org/platanios/tensorflow/api/tensors/Tensor.scala]
  Iterators created by Tensor::entriesIterator only freed their native
  resources if hasNext() returned false at least once. Now they are
  handled by Disposer.
  Removed the reference from Tensor::entriesIterator to the Tensor it originated from
  to allow it to be GC'd.

[org/platanios/tensorflow/api/utilities/Disposer.scala]
  Disposer.records is now a ConcurrentHashMap which should reduce contention.
  Removed synchronization from Disposer.add since both the ref queue and
  records should be perfectly thread safe and the Disposer thread wasn't
  synchronizing anyways.

[org/platanios/tensorflow/api/utilities/Disposer.scala]
  ThreadGroupUtils was (re)moved in JDK 9 or 10. For compatability reasons,
  getRootThreadGroup was replaced by a custom implementation.

[org/platanios/tensorflow/api/core/client/SessionConfig.scala]
  Integer::new is deprecated in JDK 10 and was removed from SessionConfig
  aside from fringe cases where the boxed ints are compared or hashed by
  object identity, this should not cause an issue.

P.S.: Would it be possible to get some v0.2._ or v0.2._-dev branch to pull request onto?