### PR TITLE
Update to SBT 1.2.6 due to https://github.com/sbt/zinc/pull/606

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.4
+sbt.version=1.2.6


### PR DESCRIPTION
Compiling current master fails for me on macOS with the following error.

```
[error] java.lang.RuntimeException: A fatal error happened in `SameAPI`: different extra api hashes for no traits!
[error]   `org.platanios.tensorflow.jni.Tensor`: 0
[error]   `org.platanios.tensorflow.jni.Tensor`: 1023284872
[error]              
[error]         at scala.sys.package$.error(package.scala:26)
[error]         at sbt.internal.inc.IncrementalNameHashing.sameAPI(IncrementalNameHashing.scala:52)
...
```

Fortunately this is easily fixed by upgrading to SBT 1.2.6. See https://github.com/sbt/zinc/pull/606 for more.