### PR TITLE
fix invalid numpy datatypes for ints and uints

### DIFF
--- a/modules/api/src/main/scala/org/platanios/tensorflow/api/io/NPY.scala
+++ b/modules/api/src/main/scala/org/platanios/tensorflow/api/io/NPY.scala
@@ -181,12 +181,12 @@ object NPY {
     case FLOAT64 => "f8"
     case INT8 => "i1"
     case INT16 => "i2"
-    case INT32 => "i3"
-    case INT64 => "i4"
+    case INT32 => "i4"
+    case INT64 => "i8"
     case UINT8 => "u1"
     case UINT16 => "u2"
-    case UINT32 => "u3"
-    case UINT64 => "u4"
+    case UINT32 => "u4"
+    case UINT64 => "u8"
     case t => throw InvalidDataTypeException(s"TensorFlow data type '$t' cannot be converted to a Numpy data type.")
   }
 }


### PR DESCRIPTION
tensorflow datatype to numpy dtypes conversion was wrong (and also was inconsistent with numpy_dtypes to tensorflow). this bug caused the `writeNPY` function to not working.