### PR TITLE
Fix compilation of Tensor.scala with JDK 11

### DIFF
--- a/modules/api/src/main/scala/org/platanios/tensorflow/api/tensors/Tensor.scala
+++ b/modules/api/src/main/scala/org/platanios/tensorflow/api/tensors/Tensor.scala
@@ -1047,7 +1047,7 @@ object Tensor {
         } else {
           val direct = ByteBuffer.allocateDirect(numBytes.toInt)
           val bufferCopy = buffer.duplicate()
-          direct.put(bufferCopy.limit(bufferCopy.position + numBytes.toInt).asInstanceOf[ByteBuffer])
+          direct.put(bufferCopy.limit(bufferCopy.position() + numBytes.toInt).asInstanceOf[ByteBuffer])
           direct
         }
       }


### PR DESCRIPTION
`sbt compile` fails with the following error when compiling with JDK 11:
```
[error] /home/vkorenev/Projects/Scala/tensorflow_scala/modules/api/src/main/scala/org/platanios/tensorflow/api/tensors/Tensor.scala:1050:50: ambiguous reference to overloaded definition,
[error] both method position in class ByteBuffer of type (x$1: Int)java.nio.ByteBuffer
[error] and  method position in class Buffer of type ()Int
[error] match expected type ?
[error]           direct.put(bufferCopy.limit(bufferCopy.position + numBytes.toInt).asInstanceOf[ByteBuffer])
[error]                                                  ^
[error] one error found
[error] (api / Compile / compileIncremental) Compilation failed
[error] Total time: 81 s, completed Jul. 10, 2019, 11:49:23 p.m.
```
Java version:
```
openjdk version "11.0.3" 2019-04-16
OpenJDK Runtime Environment (build 11.0.3+7-Ubuntu-1ubuntu218.04.1)
OpenJDK 64-Bit Server VM (build 11.0.3+7-Ubuntu-1ubuntu218.04.1, mixed mode, sharing)
```
The proposed change fixes the problem.